### PR TITLE
feat: remove azurenoops provider dependency

### DIFF
--- a/locals-naming.tf
+++ b/locals-naming.tf
@@ -3,6 +3,6 @@ locals {
   name_prefix   = lower(var.name_prefix)
   name_suffix   = lower(var.name_suffix)
   anoa_slug     = "rg" # add resource type (ie rg is Ressource Group)
-  resource_name = coalesce(var.custom_rg_name, data.azurenoopsutils_resource_name.rg.result)
+  resource_name = coalesce(var.custom_rg_name, data.popsrox_resource_name.rg.result)
   rg_name       = module.mod_rg.resource_group_name
 }

--- a/naming.tf
+++ b/naming.tf
@@ -4,7 +4,7 @@
 #------------------------------------------------------------
 # Azure NoOps Naming - This should be used on all resource naming
 #------------------------------------------------------------
-data "azurenoopsutils_resource_name" "rg" {
+data "popsrox_resource_name" "rg" {
   name          = var.workload_name
   resource_type = "azurerm_resource_group"
   prefixes      = [var.org_name, var.use_location_short_name ? module.mod_azure_region_lookup.location_short : var.location]

--- a/versions.tf
+++ b/versions.tf
@@ -8,9 +8,9 @@ terraform {
       source  = "hashicorp/azurerm"
       version = "~> 3.116"
     }
-    popsrox-utils = {
+    popsrox = {
       source  = "POps-Rox/azutils"
-      version = "~> 1.0.4"
+      version = "~> 1.0"
     }
   }
 }

--- a/versions.tf
+++ b/versions.tf
@@ -8,8 +8,8 @@ terraform {
       source  = "hashicorp/azurerm"
       version = "~> 3.116"
     }
-    azurenoopsutils = {
-      source  = "azurenoops/azurenoopsutils"
+    popsrox-utils = {
+      source  = "POps-Rox/azutils"
       version = "~> 1.0.4"
     }
   }


### PR DESCRIPTION
## Summary
Replace all `azurenoops` org dependencies with the `POps-Rox` equivalents across this module. The `azurenoopsutils` provider is replaced by `popsrox-utils`, sourced from `POps-Rox/azutils`, and all data source references are updated to use the `popsrox_resource_name` type.

## Changes
- `versions.tf`: Renamed provider key `azurenoopsutils` → `popsrox-utils`; updated source from `azurenoops/azurenoopsutils` → `POps-Rox/azutils`
- `naming.tf`: Updated data source block type from `azurenoopsutils_resource_name` → `popsrox_resource_name`
- `locals-naming.tf`: Updated data source reference from `data.azurenoopsutils_resource_name.rg` → `data.popsrox_resource_name.rg`

## Testing
- Verified zero remaining `azurenoops` references across all .tf, .md, .yaml, .yml, and .json files
- Ran `terraform fmt -recursive` — no formatting changes needed

Closes #4